### PR TITLE
Fixes #120 - Round basin characteristics in report

### DIFF
--- a/src/app/sidebar-right/components-right/report/report.component.html
+++ b/src/app/sidebar-right/components-right/report/report.component.html
@@ -27,7 +27,7 @@
                     <tr *ngFor="let basin_characteristic of workflowData[i].outputs.basinCharacteristics">
                         <td>{{basin_characteristic.fcpg_parameter}}</td>
                         <td>{{basin_characteristic["description"]}}</td>
-                        <td>{{basin_characteristic["value"]}}</td>
+                        <td>{{basin_characteristic["value"] | number : '1.2'}}</td>
                         <td>{{basin_characteristic["units"]}}</td>
                     </tr>
                 </table>


### PR DESCRIPTION
Closes #120 

Round basin characteristics (the values from the lambda service) to 2 decimals in the report. 

Note: I could not recreate the issue that Kitty reported (see screenshot in #120)