### PR TITLE
Fixes #115 - Update active fire perimeters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
       - name: Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -27,7 +33,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
             ${{ runner.OS }}-
-
       - name: npm install and npm run build
         run: |
           npm ci

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -47,7 +47,7 @@ jobs:
             # Run Linter against code base #
             ################################
             - name: Lint Code Base
-              uses: github/super-linter@v3
+              uses: github/super-linter@v3.17.0
               env:
                   VALIDATE_ALL_CODEBASE: false
                   DEFAULT_BRANCH: dev

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -252,12 +252,14 @@ export class MapComponent implements OnInit {
                   this.addLayers('NHD Flowlines', true);
                   this.addLayers('Archived Wildfire Perimeters', true);
                   this.addLayers('2021 Wildfire Perimeters', true);
+                  this.addLayers('2022 Wildfire Perimeters', true);
                   this.addLayers('MTBS Fire Boundaries', true);
                   this.addLayers('Burn Severity', true);
                 }
                 if (o.text === "Query by Fire Perimeters" && o.selected === true) {
                   this.addLayers('Archived Wildfire Perimeters', true);
                   this.addLayers('2021 Wildfire Perimeters', true);
+                  this.addLayers('2022 Wildfire Perimeters', true);
                   this.addLayers('MTBS Fire Boundaries', true);
                   this.addLayers('Burn Severity', true);
                 }
@@ -412,7 +414,7 @@ export class MapComponent implements OnInit {
     this.selectedPerimeters = [];
     this.createMessage('Querying layers. Please wait.');
     Object.keys(this.workflowLayers).forEach(layerName => {
-      if (layerName === '2021 Wildfire Perimeters' || layerName === 'Archived Wildfire Perimeters') {
+      if (layerName === '2022 Wildfire Perimeters' || layerName === '2021 Wildfire Perimeters' || layerName === 'Archived Wildfire Perimeters') {
         this.workflowLayers[layerName].query().nearby(this.clickPoint, 4).returnGeometry(true)
           .run((error: any, results: any) => {
             this.findFeatures(error,results,layerName);
@@ -455,7 +457,7 @@ export class MapComponent implements OnInit {
         popupcontent += '<br>';
         if (layerName === 'MTBS Fire Boundaries') {
           this.firePerimeterLayer = L.geoJSON(feat.geometry);
-        } else if (layerName === '2021 Wildfire Perimeters' || layerName === 'Archived Wildfire Perimeters') {
+        } else if (layerName === '2022 Wildfire Perimeters' || layerName === '2021 Wildfire Perimeters' || layerName === 'Archived Wildfire Perimeters') {
           const col = layerName.indexOf('Active') > -1 ? 'yellow' : 'red';
           this.firePerimeterLayer = L.geoJSON(feat.geometry, {style: {color: col}});
         }

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -452,17 +452,22 @@ export class MapService {
             
             Object.keys(this.workflowLayers).forEach(workflowLayer => {
                 let queryString;
-                if (workflowLayer == "Archived Wildfire Perimeters" || workflowLayer == "2021 Wildfire Perimeters") {
+                if (workflowLayer == "Archived Wildfire Perimeters" || workflowLayer == "2021 Wildfire Perimeters" || workflowLayer == '2022 Wildfire Perimeters') {
                     if (workflowLayer == "Archived Wildfire Perimeters") {
-                    if (startBurnYear >= (new Date()).getFullYear()) {
-                        count++;
-                    }
-                    queryString = 'FIRE_YEAR >= ' + startBurnYear.toString() + ' AND FIRE_YEAR <= ' + endBurnYear.toString();
+                        if (startBurnYear >= (new Date()).getFullYear()) {
+                            count++;
+                        }
+                        queryString = 'FIRE_YEAR >= ' + startBurnYear.toString() + ' AND FIRE_YEAR <= ' + endBurnYear.toString();
                     } else if (workflowLayer == "2021 Wildfire Perimeters") {
-                    if (endBurnYear < (new Date()).getFullYear()) {
-                        count ++;
-                    }
-                    queryString = '1=1';
+                        if (endBurnYear < (new Date()).getFullYear()) {
+                            count ++;
+                        }
+                        queryString = '1=1';
+                    } else if (workflowLayer == "2022 Wildfire Perimeters") {
+                        if (endBurnYear < (new Date()).getFullYear()) {
+                            count ++;
+                        }
+                        queryString = '1=1';
                     }
                     this.workflowLayers[workflowLayer].query().intersects(basin).where(queryString).returnGeometry(true)
                     .run((error: any, results: any) =>  {

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -31,7 +31,7 @@
         }
         },
         {
-            "name": "2021 Wildfire Perimeters",
+            "name": "2022 Wildfire Perimeters",
             "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/CY_WildlandFire_Perimeters_ToDate/FeatureServer/0",
             "type": "agsFeature",
             "layerOptions": {
@@ -40,8 +40,17 @@
             "visible": true
         },
         {
+            "name": "2021 Wildfire Perimeters",
+            "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/Fire_History_Perimeters_Public/FeatureServer/0",
+            "type": "agsFeature",
+            "layerOptions": {
+                "zIndex": 9999
+            },
+            "visible": true
+        },
+        {
             "name": "Archived Wildfire Perimeters",
-            "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/ArcGIS/rest/services/Interagency_Fire_Perimeter_History_All_Years_Read_Only/FeatureServer/0",
+            "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/Interagency_Fire_Perimeter_History_All_Years_Read_Only/FeatureServer/0",
             "type": "agsFeature",
             "layerOptions": {
                 "zIndex": 9999
@@ -147,9 +156,13 @@
         }
     ],
     "symbols": {
-        "2021 Wildfire Perimeters": {
+        "2022 Wildfire Perimeters": {
             "color": "#EBCF26",
             "fillColor": "#EBCF26"
+        },
+        "2021 Wildfire Perimeters": {
+            "color": "#ed8f24",
+            "fillColor": "#ed8f24"
         },
         "Archived Wildfire Perimeters": {
             "color": "#ed8f24",

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -146,7 +146,7 @@
                                     },
                                     {
                                         "textLabel":"End Year",
-                                        "text":"2021"
+                                        "text":"2022"
                                     }
                                 ]
                             }


### PR DESCRIPTION
Closes #115

- A Slack reminder has been set to check the active fire perimeters layer in January each year. There doesn't seem to be an automated way to update it. 
- The following layers have been updated:
     - 2022 Wildfire Perimeters were added from the ["WFIGS - 2022 Wildland Fire Perimeters to Date"](https://data-nifc.opendata.arcgis.com/datasets/wfigs-2022-wildland-fire-perimeters-to-date) layer 
     - The 2021 Wildfire Perimeters layer now refers to ["WFIGS - Wildland Fire Perimeters Full History"](https://data-nifc.opendata.arcgis.com/datasets/wfigs-wildland-fire-perimeters-full-history), which only includes 2021 fires at this point. This may need to be renamed later.
     - Note: Archived Wildfire Perimeters remains the same (["Interagency Fire Perimeter History - All Years"](https://data-nifc.opendata.arcgis.com/datasets/interagency-fire-perimeter-history-all-years)), but this layer is no longer being updated.