### PR TITLE
Fixes #183 - Remove forests from fire basin characteristics

### DIFF
--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -189,13 +189,6 @@
             "description": "Mean January maximum temperature",
             "multiplier": 1,
             "units": "degrees Celsius"
-        },
-        
-        {
-            "fcpg_parameter" : "forests",
-            "description": "Forested area",
-            "multiplier": 1,
-            "units": "percent"
         }
     ]
     


### PR DESCRIPTION
The forests raster layer is not yet published. Because we are in Beta release, we are removing it temporarily.

Created issue #185 to add it back when it is ready. Kitty is point of contact for forest raster publication.

We should do a new release once this PR is complete.