### PR TITLE
Fixes #204 - Basin Characteristics overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed  
 
-- 
+- Issue where basin characteristics were getting overwritten but subsequent workflows
 
 ### Security  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed  
 
-- Issue where basin characteristics were getting overwritten but subsequent workflows
+- Issue where basin characteristics were getting overwritten by subsequent workflows
 
 ### Security  
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -189,7 +189,7 @@ export class MapComponent implements OnInit {
                 this._mapService.setBasinCharacteristics(basinCharacteristics);
 
                 // Streamflow Estimates
-                await this._mapService.calculateFireStreamflowEstimates(basinFeature);
+                await this._mapService.calculateFireStreamflowEstimates(basinFeature, basinCharacteristics);
                 this.createMessage("Basin characteristics and streamflow estimates were successfully calculated.");
               } else {
                 this.createMessage("Please enter valid Burn Years.", 'error');

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -532,7 +532,7 @@ export class MapService {
         });
     }
 
-    public async calculateFireStreamflowEstimates(basinFeature) {
+    public async calculateFireStreamflowEstimates(basinFeature, basinCharacteristics) {
         let url = this.configSettings.NSSServices + "scenarios?regions=74&statisticgroups=39";
         let postBody;
         await this._http.get(url, {headers: this.authHeader}).subscribe(response => {
@@ -543,14 +543,14 @@ export class MapService {
                 parameters.forEach(parameter => {
                 switch (parameter["code"]) {
                     case "DRNAREA":
-                    parameter["value"] = (area(basinFeature) / 1000000);; 
-                    break;
+                        parameter["value"] = (area(basinFeature) / 1000000);; 
+                        break;
                     case "I_30_M":
-                    parameter["value"] = this.basinCharacteristics.filter(parameter => parameter.fcpg_parameter == "i2y30")[0]["value"];
-                    break;
+                        parameter["value"] = basinCharacteristics.filter(parameter => parameter.fcpg_parameter == "i2y30")[0]["value"];
+                        break;
                     case "BRNAREA":
-                    parameter["value"] = 0.0; // This needs to come from this.burnedArea but doesn't matter right now because it is only used for Level 2 or 3 equations.
-                    break;
+                        parameter["value"] = 0.0; // This needs to come from this.burnedArea but doesn't matter right now because it is only used for Level 2 or 3 equations.
+                        break;
                     default:
                     parameter["value"] = 0.0;
                 }

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -519,10 +519,11 @@ export class MapService {
             // let url = "https://hgst52v4o1.execute-api.us-east-2.amazonaws.com/cogQuery/cogQuery?latitude=" + latitude + "&longitude=" + longitude;
             await this._http.post(url, {headers: this.authHeader}).subscribe(response => {
                 let parameterValues = response["results"];
-                this.configSettings.parameters.forEach(parameter => {
+                var basinParameters = JSON.parse(JSON.stringify(this.configSettings.parameters));
+                basinParameters.forEach(parameter => {
                     parameter.value = parameterValues[parameter.fcpg_parameter] * parameter.multiplier;
                 });
-                resolve(this.configSettings.parameters);
+                resolve(basinParameters);
             }, error => {
                 console.log(error);
                 this._loaderService.hideFullPageLoad();

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -546,7 +546,7 @@ export class MapService {
                     parameter["value"] = (area(basinFeature) / 1000000);; 
                     break;
                     case "I_30_M":
-                    parameter["value"] = this.configSettings.parameters.filter(parameter => parameter.fcpg_parameter == "i2y30")[0]["value"];
+                    parameter["value"] = this.basinCharacteristics.filter(parameter => parameter.fcpg_parameter == "i2y30")[0]["value"];
                     break;
                     case "BRNAREA":
                     parameter["value"] = 0.0; // This needs to come from this.burnedArea but doesn't matter right now because it is only used for Level 2 or 3 equations.


### PR DESCRIPTION
Closes #204 

The issue was that the basin characteristic values were being stored in the [parameters array in the config.json](https://github.com/USGS-WiM/StreamStats-National/blob/dev/src/assets/config.json#L184L213).