### PR TITLE
Fixes #222, #229, #226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added 
 
 - Allows users to enter downstream distance in "Query by Fire Perimeters" workflow
+- Descriptions to workflows and steps
 
 ### Changed  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added 
 
-- 
+- Allows users to enter downstream distance in "Query by Fire Perimeters" workflow
 
 ### Changed  
 
 - Split 'Select a Fire Perimeter' step in 'Query by Fire Perimeters' workflow into two seperate steps. The first is to select your fire perimeter the second it to start the trace. 
+- Updated layout
 
 ### Deprecated 
 

--- a/src/app/content-right/report-builder/workflow-selection/workflow-selection.component.html
+++ b/src/app/content-right/report-builder/workflow-selection/workflow-selection.component.html
@@ -4,6 +4,6 @@
 	<button *ngFor="let workflow of workflows; let i = index" class="workflow-choice" (click)="selectWorkflow(workflow)" aria-label="{{workflow.title}} Workflow">
 		<i class={{workflow.icon}}></i>
 		<b>{{ workflow.title }}</b>
-		<p>Example short description of this workflow</p>
+		<p>{{ workflow.description }}</p>
 	</button>
 </div>

--- a/src/app/content-right/report-builder/workflow/workflow.component.html
+++ b/src/app/content-right/report-builder/workflow/workflow.component.html
@@ -32,7 +32,7 @@
 					<span class="step-number">{{i+1}}</span>
 					<span class="step-description">
 						<b>{{step.value.label}}</b>
-						This is a short description for the step
+						<p>{{step.value.description}}</p>
 					</span>
 				</div>
 

--- a/src/app/content-right/report-builder/workflow/workflow.component.spec.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.spec.ts
@@ -13,6 +13,7 @@ let mockWorkflow: Workflow = {
   steps: [{
     label: "Select Your Favorite Color",
     name: "selectColor",
+    description: "Slect your favorite color from the list below.",
     type: "checkbox",
     value: "",
     validators: { required: true },
@@ -24,6 +25,7 @@ let mockWorkflow: Workflow = {
           { 
             label: "nested step label", 
             name: "name", 
+            description:"nest step description",
             type: "type" ,
             value: "value"
           }] 

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -163,7 +163,6 @@ export class WorkflowComponent implements OnInit {
   }
 
   public getSteps(form: any) {
-    console.log(form.controls.steps.controls)
     return form.controls.steps.controls;
   }
   public getOptions(form: any) {

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -34,6 +34,7 @@ export class WorkflowComponent implements OnInit {
   public selectedPerimeters;
   public firePerimetersLayers;
   public output:any = {};
+  public downstreamDist;
 
   constructor(private _fb: FormBuilder, public _mapService: MapService, private _workflowService: WorkflowService) {
     this.workflowForm = this._fb.group({
@@ -97,7 +98,11 @@ export class WorkflowComponent implements OnInit {
     this._mapService.firePerimetersLayers.subscribe((layers) => {
       this.firePerimetersLayers = layers;
     });
-    
+
+    // Get downstream trace distance
+    this._mapService.downstreamDist.subscribe((downstreamDist) => {
+      this.downstreamDist = downstreamDist;
+    });
   }
 
   public setTitle() {
@@ -204,6 +209,7 @@ export class WorkflowComponent implements OnInit {
           this.output = {
             'clickPoint': this.clickedPoint, 
             'layers': this.firePerimetersLayers,
+            'downstreamDist' : this.downstreamDist,
             'selectedPerimetersInfo': this.selectedPerimeters};
         }
         break;

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -118,6 +118,7 @@ export class WorkflowComponent implements OnInit {
         label: step.label,
         name: step.name,
         type: step.type,
+        description: step.description,
         completed: [],
         clickPoint: [],
         output: [],
@@ -137,6 +138,7 @@ export class WorkflowComponent implements OnInit {
               label: s.label,
               name: s.name,
               type: s.type,
+              description: s.description,
               completed: [],
               clickPoint: [],
               output: [],
@@ -161,6 +163,7 @@ export class WorkflowComponent implements OnInit {
   }
 
   public getSteps(form: any) {
+    console.log(form.controls.steps.controls)
     return form.controls.steps.controls;
   }
   public getOptions(form: any) {

--- a/src/app/content-right/report/report.component.html
+++ b/src/app/content-right/report/report.component.html
@@ -22,7 +22,7 @@
 
 
 					<!-- Click Point -->
-					<div class="data" *ngIf="output.key=='clickPoint'">Lat/Lon: <b>({{output.value.lat | number : '1.5'}}, {{output.value.lng | number : '1.5'}})</b></div>
+					<div class="data" *ngIf="output.key=='clickPoint'">Clicked Point (Latitude, Longitude): <b>{{output.value.lat | number : '1.5'}}, {{output.value.lng | number : '1.5'}}</b></div>
 					
 					<!-- Delineation -->
 					<div *ngIf="output.key=='selectDelineationProcess'">Delineation Process: {{output.value}}</div>
@@ -76,6 +76,7 @@
 						</table>
 					</div>
 					<!-- Fire Hydrology: Query by Fire Perimeters-->
+					<div *ngIf="output.key=='downstreamDist'">Downstream Trace Distance (miles): {{output.value}}</div>
 					<div *ngIf="output.key=='selectedPerimetersInfo'"> Selected Perimeters Information:
 						<span *ngFor="let perimeter of workflowData[i].outputs.selectedPerimetersInfo">
 								<div>{{perimeter.Key}}:</div>
@@ -90,8 +91,6 @@
 						</span>
 					</div>
 
-
-
 				</span>
 
 			<!-- Card footer -->
@@ -102,11 +101,6 @@
 					<i class="fas fa-trash-alt mright-xs"></i>
 					<span>Delete</span>
 				</button>
-
-
-
-
-
 </div>
 
 
@@ -167,10 +161,7 @@
 				<p>{{data.title}} Outputs:</p>
 				<div *ngFor="let output of data.outputs | keyvalue: unsortedKeys">
 					<!-- Click Point -->
-					<li *ngIf="output.key=='clickPoint'">Clicked Point (Latitude, Longitude): ({{output.value.lat | number : '1.5'}}, {{output.value.lng | number : '1.5'}})</li>
-					<!-- Example Workflow -->
-					<li *ngIf="output.key=='selectColor'">Color Selected: {{output.value}}</li>
-					<li *ngIf="output.key=='enterText'">Text Entered: {{output.value}}</li>
+					<li *ngIf="output.key=='clickPoint'">Clicked Point (Latitude, Longitude): {{output.value.lat | number : '1.5'}}, {{output.value.lng | number : '1.5'}}</li>
 					<!-- Delineation -->
 					<li *ngIf="output.key=='selectDelineationProcess'">Delineation Process: {{output.value}}</li>
 					<!-- Fire Hydrology: Query by Basin -->
@@ -227,7 +218,8 @@
 							</table>
 						</ul>
 					</li>
-					<!-- Fire Hydrology: Query by Fire Perimeters-->						
+					<!-- Fire Hydrology: Query by Fire Perimeters-->	
+					<li *ngIf="output.key=='downstreamDist'">Downstream Trace Distance (miles): {{output.value}}</li>					
 					<li *ngIf="output.key=='selectedPerimetersInfo'"> Selected Perimeters Information:
 						<span *ngFor="let perimeter of workflowData[i].outputs.selectedPerimetersInfo">
 							<ul>

--- a/src/app/content-right/report/report.component.html
+++ b/src/app/content-right/report/report.component.html
@@ -76,7 +76,7 @@
 						</table>
 					</div>
 					<!-- Fire Hydrology: Query by Fire Perimeters-->
-					<div *ngIf="output.key=='downstreamDist'">Downstream Trace Distance (miles): {{output.value}}</div>
+					<div *ngIf="output.key=='downstreamDist'">Downstream Trace Distance (kilometers): {{output.value}}</div>
 					<div *ngIf="output.key=='selectedPerimetersInfo'"> Selected Perimeters Information:
 						<span *ngFor="let perimeter of workflowData[i].outputs.selectedPerimetersInfo">
 								<div>{{perimeter.Key}}:</div>
@@ -219,7 +219,7 @@
 						</ul>
 					</li>
 					<!-- Fire Hydrology: Query by Fire Perimeters-->	
-					<li *ngIf="output.key=='downstreamDist'">Downstream Trace Distance (miles): {{output.value}}</li>					
+					<li *ngIf="output.key=='downstreamDist'">Downstream Trace Distance (kilometers): {{output.value}}</li>					
 					<li *ngIf="output.key=='selectedPerimetersInfo'"> Selected Perimeters Information:
 						<span *ngFor="let perimeter of workflowData[i].outputs.selectedPerimetersInfo">
 							<ul>

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -20,6 +20,7 @@ describe('MapComponent', () => {
       {
           "label": "Select a Fire Hydrology Query Method",
           "name": "selectFireHydroProcess",
+          "description":"",
           "type": "checkbox",
           "value": "",
           "options":

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -20,7 +20,7 @@ describe('MapComponent', () => {
       {
           "label": "Select a Fire Hydrology Query Method",
           "name": "selectFireHydroProcess",
-          "description":"",
+          "description":"Choose from list of fire hydrology query methods.",
           "type": "checkbox",
           "value": "",
           "options":
@@ -32,6 +32,7 @@ describe('MapComponent', () => {
                   [
                       {
                           "label": "Select a Point",
+                          "description": "",
                           "name": "selectFireHydroBasin",
                           "type": "subscription",
                           "value": "",
@@ -57,6 +58,7 @@ describe('MapComponent', () => {
                     {
                         "label": "Select a Fire Perimeter",
                         "name": "selectFireHydroPerimeter",
+                        "description": "",
                         "type": "subscription",
                         "value": "",
                         "validators": 

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -20,7 +20,7 @@ describe('MapComponent', () => {
       {
           "label": "Select a Fire Hydrology Query Method",
           "name": "selectFireHydroProcess",
-          "description":"Choose from list of fire hydrology query methods.",
+          "description":"",
           "type": "checkbox",
           "value": "",
           "options":

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -173,7 +173,7 @@ export class MapComponent implements OnInit {
           if (this.workflowData.steps[1].name === "selectFireHydroBasin" && this.workflowData.steps[2].completed) {
             this.queryBurnYear();
           }
-          if (this.workflowData.steps[1].name === "selectFireHydroPerimeter"  && this.workflowData.steps[2].completed) {
+          if (this.workflowData.steps[1].name === "selectFireHydroPerimeter"  && this.workflowData.steps[3].completed) {
             this._loaderService.showFullPageLoad();
             this.addTraceLayer(this.traceData);
           }
@@ -537,8 +537,11 @@ export class MapComponent implements OnInit {
 
   public addTraceLayer(data) { 
     var dataLength = (data.length);
+    var downstreamDist = this.workflowData.steps[2].options[0].text
+    this._mapService.setDownstreamDist(downstreamDist);
+
     data.forEach(async (trace, index) => {
-      var data = await this._mapService.trace(trace).toPromise();
+      var data = await this._mapService.trace(trace, downstreamDist).toPromise();
       if (data && data.features) {
         data.features.forEach((feature) => {
           if (feature.id == "flowlinesGeom") { // Only print out the flow lines

--- a/src/app/shared/interfaces/workflow/nestedsteps.ts
+++ b/src/app/shared/interfaces/workflow/nestedsteps.ts
@@ -3,6 +3,7 @@ import { Options } from './options';
 export interface NestedSteps {
     label: string;
     name: string;
+    description: string;
     value: string;
     type: string;
     validators?: any;

--- a/src/app/shared/interfaces/workflow/steps.ts
+++ b/src/app/shared/interfaces/workflow/steps.ts
@@ -3,6 +3,7 @@ import { Options } from './options';
 export interface Steps {
     label: string;
     name: string;
+    description: string;
     value: string;
     type: string;
     validators?: any;

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -632,13 +632,22 @@ export class MapService {
         return this._streamflowEstimates.asObservable();
     }
 
+    // Get basin area
+    private _downstreamDist: Subject<any> = new Subject<any>();
+    public setDownstreamDist(value) {
+        this._downstreamDist.next(value);
+    }
+    public get downstreamDist(): any {
+        return this._downstreamDist.asObservable();
+    }
+
     // Query Fire Perimeters
-    public trace(geojson: any) {
+    public trace(geojson: any, downstreamDist) {
         const httpOptions = { headers: new HttpHeaders({ 'Content-Type': 'application/json; charset=utf-8' }) };
         var data = {
             "data": geojson,
             "get_flowlines": true,
-	        "downstream_dist": 15
+	        "downstream_dist": downstreamDist
         }
 
         return this._http.post<any>(this.configSettings.nldiPolygonQuery, data, httpOptions)

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -632,7 +632,7 @@ export class MapService {
         return this._streamflowEstimates.asObservable();
     }
 
-    // Get basin area
+    // Get downstream trace distance
     private _downstreamDist: Subject<any> = new Subject<any>();
     public setDownstreamDist(value) {
         this._downstreamDist.next(value);

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -8,7 +8,7 @@
         [
             {
                 "label": "Select Delineation Process",
-                "description": "Choose from list of delineation processes.",
+                "description": "",
                 "name": "selectDelineationProcess",
                 "type": "checkbox",
                 "options":
@@ -31,7 +31,7 @@
                 "options":
                 [
                     {
-                        "text":"Select a delineation point on the map.",
+                        "text":"Select a delineation point on a blue stream line on the map.",
                         "selected": false
                     }
                 ]
@@ -53,7 +53,7 @@
         [
             {
                 "label": "Select a Fire Hydrology Query Method",
-                "description": "Choose from list of fire hydrology query methods.",
+                "description": "",
                 "name": "selectFireHydroProcess",
                 "type": "checkbox",
                 "options":
@@ -75,7 +75,7 @@
                                 "options": 
                                 [
                                     {
-                                        "text": "Select a delineation point on the map.",
+                                        "text": "Select a delineation point on a blue stream line on the map.",
                                         "selected": false
                                     }
                                 ]
@@ -127,7 +127,7 @@
                             },
                             {
                                 "label": "Enter Downstream Trace Distance",
-                                "description": "Enter a downstream trace distance in miles.",
+                                "description": "Enter the distance (kilometers) to trace stream lines downstream of the fire perimeter.",
                                 "name": "enterDownstreamDistance",
                                 "type": "text",
                                 "validators": 

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -120,6 +120,21 @@
                                 ]
                             },
                             {
+                                "label": "Enter Downstream Trace Distance in Miles",
+                                "name": "enterDownstreamDistance",
+                                "type": "text",
+                                "validators": 
+                                {
+                                    "required": true
+                                },
+                                "options": 
+                                [
+                                    {
+                                        "textLabel":"Downstream Trace Distance"
+                                    }
+                                ]
+                            },
+                            {
                                 "label": "Trace Fire Perimeter",
                                 "name": "traceFireHydroPerimeter",
                                 "type": "subscription",

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -1,13 +1,14 @@
 [
     {
         "title": "Delineation",
-        "description": "Delineate a basin based on a click point. Delineations available using state data, national datasets, etc.",
+        "description": "Delineate a basin based on a click point.",
         "functionality": "Core",
         "icon": "far fa-map-marker",
         "steps":
         [
             {
                 "label": "Select Delineation Process",
+                "description": "Choose from list of delineation processes.",
                 "name": "selectDelineationProcess",
                 "type": "checkbox",
                 "options":
@@ -20,6 +21,7 @@
             },
             {
                 "label":"Select Delineation Point",
+                "description": "",
                 "name": "selectDelineationPoint",
                 "type": "subscription",
                 "validators": 
@@ -29,7 +31,7 @@
                 "options":
                 [
                     {
-                        "text":"Select a delineation point on the map",
+                        "text":"Select a delineation point on the map.",
                         "selected": false
                     }
                 ]
@@ -44,13 +46,14 @@
     },
     {
         "title": "Fire Hydrology",
-        "description": "Fire hydrology description here.",
+        "description": "Query fire hydrology based on delineated basin or fire perimeter.",
         "functionality": "Core",
         "icon": "far fa-fire-alt",
         "steps":
         [
             {
                 "label": "Select a Fire Hydrology Query Method",
+                "description": "Choose from list of fire hydrology query methods.",
                 "name": "selectFireHydroProcess",
                 "type": "checkbox",
                 "options":
@@ -61,7 +64,8 @@
                         "nestedSteps": 
                         [
                             {
-                                "label": "Select a Point",
+                                "label": "Select Delineation Point",
+                                "description": "",
                                 "name": "selectFireHydroBasin",
                                 "type": "subscription",
                                 "validators": 
@@ -71,14 +75,15 @@
                                 "options": 
                                 [
                                     {
-                                        "text": "Select delineation point on the map",
+                                        "text": "Select a delineation point on the map.",
                                         "selected": false
                                     }
                                 ]
                             },
                             {
                                 "label":"Burn Area Year Range",
-                                "name": "burnAreaStartYear",
+                                "description": "Enter a start and end date for the burn area year range.",
+                                "name": "burnAreaYearRange",
                                 "type": "text",
                                 "validators": 
                                 {
@@ -105,6 +110,7 @@
                         [
                             {
                                 "label": "Select a Fire Perimeter",
+                                "description": "",
                                 "name": "selectFireHydroPerimeter",
                                 "type": "subscription",
                                 "validators": 
@@ -114,13 +120,14 @@
                                 "options": 
                                 [
                                     {
-                                        "text": "Select a fire perimeter on the map",
+                                        "text": "Select a fire perimeter on the map.",
                                         "selected": false
                                     }
                                 ]
                             },
                             {
-                                "label": "Enter Downstream Trace Distance in Miles",
+                                "label": "Enter Downstream Trace Distance",
+                                "description": "Enter a downstream trace distance in miles.",
                                 "name": "enterDownstreamDistance",
                                 "type": "text",
                                 "validators": 
@@ -136,6 +143,7 @@
                             },
                             {
                                 "label": "Trace Fire Perimeter",
+                                "description": "",
                                 "name": "traceFireHydroPerimeter",
                                 "type": "subscription",
                                 "validators": 
@@ -145,7 +153,7 @@
                                 "options": 
                                 [
                                     {
-                                        "text": "Click 'Next' to trace downstream",
+                                        "text": "Click 'Next' to trace downstream.",
                                         "selected": false
                                     }
                                 ]

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -29,7 +29,7 @@
                 "options":
                 [
                     {
-                        "text":"Click on the map",
+                        "text":"Select a delineation point on the map",
                         "selected": false
                     }
                 ]
@@ -71,7 +71,7 @@
                                 "options": 
                                 [
                                     {
-                                        "text": "Click on the map",
+                                        "text": "Select delineation point on the map",
                                         "selected": false
                                     }
                                 ]
@@ -114,7 +114,7 @@
                                 "options": 
                                 [
                                     {
-                                        "text": "Click on the map",
+                                        "text": "Select a fire perimeter on the map",
                                         "selected": false
                                     }
                                 ]


### PR DESCRIPTION
222 - add steps in "Query by Fire Perimeters" workflow to allow users to select downstream trace distance. Add to report and print modal.
229 - Updated 'Click on the Map' text to say 'Select a delineation point on the map.'
226 - added workflow and step descriptions. You can either add text or leave blank if there is no further explanation. 
