### PR TITLE
Fixes #247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Descriptions to workflows and steps
 - Added cursor attribute to workflows
 - Basin characteristics computation to "Delineation" workflow
+- Disabled 'next' until user adequately completes the step.
 
 ### Changed  
 
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated to google analytics 4
 - Burn Severity is turned off by default for Fire Hydrology workflows
 - Some checkboxes are now radio buttons where appropriate
+- 'Query by Fire Perimeters' workflow to 'Query by Fire Perimeter' 
 
 ### Deprecated 
 
@@ -35,7 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed 
 
-- 
+- Removed 'Trace Fire Perimeter' step
 
 ### Fixed  
 

--- a/src/app/content-right/content-right.component.ts
+++ b/src/app/content-right/content-right.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewChildren} from '@angular/core';
+import {Component, OnInit, ViewChildren, ChangeDetectorRef} from '@angular/core';
 import {WorkflowService} from '../shared/services/workflow.service';
 
 @Component({selector: 'app-content-right', templateUrl: './content-right.component.html', styleUrls: ['./content-right.component.scss']})
@@ -12,7 +12,7 @@ export class ContentRightComponent implements OnInit {
     public reportBuilderTab = "selection";
     public formData : any;
 
-    constructor(private _workflowService : WorkflowService) {}
+    constructor(private _workflowService : WorkflowService, private changeDetector : ChangeDetectorRef) {}
 
     ngOnInit(): void {
 
@@ -26,6 +26,10 @@ export class ContentRightComponent implements OnInit {
             this.formData = data;
         })
 
+    }
+
+    ngAfterContentChecked() : void {
+        this.changeDetector.detectChanges();
     }
 
     public removeWorkFlow() {

--- a/src/app/content-right/report-builder/workflow/workflow.component.html
+++ b/src/app/content-right/report-builder/workflow/workflow.component.html
@@ -49,7 +49,7 @@
 	
 							<!-- Text -->
 							<div *ngIf="step.value.type === 'text'">
-								<input type="number" class="usa-input" (input)="onChangeText($event.target.value)" formControlName="text" />
+								<input type="number" class="usa-input" (input)="onChangeText($event.target.value)" formControlName="text"/>
 							</div>
 						
 						</div>

--- a/src/app/content-right/report-builder/workflow/workflow.component.html
+++ b/src/app/content-right/report-builder/workflow/workflow.component.html
@@ -75,7 +75,7 @@
 				<div class="step-actions">
 					<div></div>
 					<!-- Next Button -->
-					<button (click)="nextStep(i); onContinue(workflowForm.value)" class="usa-button mtop-xs" [disabled]="stepsCompleted > i">Next</button>
+					<button (click)="nextStep(i); onContinue(workflowForm.value)" class="usa-button mtop-xs" [disabled]="!checkStep(step.value.type, i) || stepsCompleted > i">Next</button>
 				</div>
 	
 	

--- a/src/app/content-right/report-builder/workflow/workflow.component.html
+++ b/src/app/content-right/report-builder/workflow/workflow.component.html
@@ -30,13 +30,13 @@
 
 							<!-- Radio Buttons -->
 							<div class="workflow-radio-group" *ngIf="step.value.type === 'radio'">
-								<input type="radio" id="workflowRadio{{j}}" name="selectedRadio" formControlName="selectedRadio" (change)="onRadioChange(option.value, step.value)">
+								<input type="radio" id="workflowRadio{{j}}" name="selected" formControlName="selected" (change)="onRadioChange(option.value, step.value)">
 								<label class="mleft-xs" for="workflowRadio{{j}}" >{{option.value.text}}</label>
 							</div>
 	
 							<!-- Checkboxes -->
 							<div class="workflow-checkbox-group" *ngIf="step.value.type === 'checkbox'">
-								<input type="checkbox" id="workflowCheckbox{{j}}" name="selectedCheckbox" formControlName="selectedCheckbox" (change)="onCheckboxChange(option.value, step.value)">
+								<input type="checkbox" id="workflowCheckbox{{j}}" name="selected" formControlName="selected" (change)="onCheckboxChange(option.value, step.value)">
 								<label class="mleft-xs" for="workflowCheckbox{{j}}" >{{option.value.text}}</label>
 							</div>
 	
@@ -49,7 +49,7 @@
 	
 							<!-- Text -->
 							<div *ngIf="step.value.type === 'text'">
-								<input type="text" class="usa-input" formControlName="text"/>
+								<input type="text" class="usa-input" (input)="onChangeText($event.target.value)" formControlName="text" />
 							</div>
 						
 						</div>

--- a/src/app/content-right/report-builder/workflow/workflow.component.html
+++ b/src/app/content-right/report-builder/workflow/workflow.component.html
@@ -49,7 +49,7 @@
 	
 							<!-- Text -->
 							<div *ngIf="step.value.type === 'text'">
-								<input type="text" class="usa-input" (input)="onChangeText($event.target.value)" formControlName="text" />
+								<input type="number" class="usa-input" (input)="onChangeText($event.target.value)" formControlName="text" />
 							</div>
 						
 						</div>

--- a/src/app/content-right/report-builder/workflow/workflow.component.html
+++ b/src/app/content-right/report-builder/workflow/workflow.component.html
@@ -6,22 +6,6 @@
 	
 	<form [formGroup]="workflowForm" (ngSubmit)="onContinue(workflowForm.value)" #data>
 	
-		<!-- USWDS Step Indicator -->
-		<!-- <div class="usa-step-indicator usa-step-indicator--counters-sm" aria-label="progress" formArrayName="steps">
-			<ol class="usa-step-indicator__segments">
-	
-				<li class="usa-step-indicator__segment usa-step-indicator__segment--complete" 
-					*ngFor='let step of getSteps(workflowForm)| slice:0:stepsCompleted+1; let i = index'>
-	
-					<span class="usa-step-indicator__segment-label">
-						Step {{i+1}}:
-						<span class="usa-sr-only">completed</span>
-					</span>
-				</li>
-	
-			</ol>
-		</div> -->
-	
 		<!-- Form -->
 		<div formArrayName="steps" class="workflow-steps">
 	
@@ -52,7 +36,7 @@
 	
 							<!-- Checkboxes -->
 							<div class="workflow-checkbox-group" *ngIf="step.value.type === 'checkbox'">
-								<input type="checkbox" id="workflowCheckbox{{j}}" name="workflowRadioSelection" formControlName="selectedCheckbox" (change)="onCheckboxChange(option.value, step.value)">
+								<input type="checkbox" id="workflowCheckbox{{j}}" name="selectedCheckbox" formControlName="selectedCheckbox" (change)="onCheckboxChange(option.value, step.value)">
 								<label class="mleft-xs" for="workflowCheckbox{{j}}" >{{option.value.text}}</label>
 							</div>
 	

--- a/src/app/content-right/report-builder/workflow/workflow.component.spec.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.spec.ts
@@ -94,7 +94,6 @@ describe('WorkflowComponent', () => {
     fixture = TestBed.createComponent(WorkflowComponent);
     component = fixture.componentInstance;
     component.workflow = mockWorkflow;
-    component.formData = null;
     fixture.detectChanges();
   });
 
@@ -175,7 +174,6 @@ describe('WorkflowComponent', () => {
   });
 
   it('#finishedWorkflow should update services', () => {
-    component.formData = mockFormData;
     spyOn(component, 'finishedWorkflow').and.callThrough();
     const formData = {
       title: "Example Workflow",

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
-import { Console } from 'console';
 import * as L from 'leaflet';
-import { last, shareReplay, take } from 'rxjs/operators';
 import { Workflow } from 'src/app/shared/interfaces/workflow/workflow';
 import { MapService } from 'src/app/shared/services/map.service';
 import { WorkflowService } from 'src/app/shared/services/workflow.service';
@@ -294,7 +292,7 @@ export class WorkflowComponent implements OnInit {
   }
 
   public checkStep(type, stepNum) {
-    if (type == 'checkbox') {
+    if (type == 'checkbox' || type == 'radio') {
       let optionsArray = this.workflowFormData[stepNum].get('options') as FormArray;
       var result;
       optionsArray.controls.forEach((element) => {
@@ -311,15 +309,6 @@ export class WorkflowComponent implements OnInit {
       if (this.text && this.text.length > 0) {
         return(true)
       }
-    } else if (type == 'radio') {
-      let optionsArray = this.workflowFormData[stepNum].get('options') as FormArray;
-      var result;
-      optionsArray.controls.forEach((element) => {
-        if (element.value.selected == true) {
-          result = true
-        }
-      });
-      return(result)
     }
   }
 

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -15,10 +15,8 @@ import { WorkflowService } from 'src/app/shared/services/workflow.service';
 export class WorkflowComponent implements OnInit {
 
   @Input() workflow!: Workflow;
-  @Input() formData: any;
 
   public workflowForm: FormGroup;
-  public selectedWorkflow: any;
   public stepsArray: FormArray;
   public stepsCompleted: number = 0;
   public numberOfSteps: number;
@@ -27,7 +25,7 @@ export class WorkflowComponent implements OnInit {
   public text;
   //Subscriptions 
   public downstreamSubscription;
-  public fireLayersSubscription;
+  public fireTraceSubscription;
   public streamflowSubscription;
   public bcSubscription;
   public geologyReportSubscription;
@@ -35,7 +33,7 @@ export class WorkflowComponent implements OnInit {
   public burnYearsSubscription;
   public basinAreaSubscription;
   public deleationSubscription;
-  public firePerimetersSubscription;
+  public firePerimeterSubscription;
   // Delination output
   public clickedPoint;
   public splitCatchmentLayer;
@@ -47,8 +45,8 @@ export class WorkflowComponent implements OnInit {
   public basinCharacteristics;
   public streamflowEstimates;
   // Fire Hydrology: Query by Fire Perimeters output
-  public selectedPerimeters;
-  public firePerimetersLayers;
+  public selectedFirePerimeter;
+  public fireTraceLayer;
   public output:any = {};
   public downstreamDist;
   
@@ -64,18 +62,14 @@ export class WorkflowComponent implements OnInit {
 
   ngOnInit(): void {
 
-    if (this.formData === null) {
-      // Set steps if there is no prior form data
-      this.setSteps();
-    }
-
+    this.setSteps();
+    
     // Get clicked point
     this._mapService.clickPoint.subscribe((point: {}) => {
       this.clickedPoint = point;
     });
     // Get delineation and basin area
     this.deleationSubscription = this._mapService.delineationPolygon.subscribe((poly: any) => {
-      console.log(poly)
       var basin = poly;
       if (basin) {  
         this.setSubComplete(this.stepsCompleted);
@@ -107,14 +101,13 @@ export class WorkflowComponent implements OnInit {
       this.streamflowEstimates = streamflowEstimates;
     });    
     // Get selected fire perimeters
-    this.firePerimetersSubscription =this._mapService.selectedPerimeters.subscribe((perimeters) => {
+    this.firePerimeterSubscription =this._mapService.selectedFirePerimeter.subscribe((perimeter) => {
       this.setSubComplete(this.stepsCompleted)
-      this.selectedPerimeters = perimeters;
+      this.selectedFirePerimeter = perimeter;
     });
     // Get selected fire perimeter layer
-    this.fireLayersSubscription =this._mapService.firePerimetersLayers.subscribe((layers) => {
-      console.log('firePerimetersLayers')
-      this.firePerimetersLayers = layers;
+    this.fireTraceSubscription =this._mapService.fireTraceLayers.subscribe((layers) => {
+      this.fireTraceLayer = layers;
     });
     // Get downstream trace distance
     this.downstreamSubscription =this._mapService.downstreamDist.subscribe((downstreamDist) => {
@@ -138,10 +131,7 @@ export class WorkflowComponent implements OnInit {
   }
 
   public setSubComplete(step) {
-    console.log(step)
-    console.log(this.workflowData)
     this.workflowData.steps[step].subComplete = true;
-
   }
 
   public setSteps() {
@@ -265,9 +255,9 @@ export class WorkflowComponent implements OnInit {
         } else if (this.workflowForm.value.steps[1].name === "selectFireHydroPerimeter") {
           this.output = {
             'clickPoint': this.clickedPoint, 
-            'layers': this.firePerimetersLayers,
+            'layers': this.fireTraceLayer,
             'downstreamDist' : this.downstreamDist,
-            'selectedPerimetersInfo': this.selectedPerimeters};
+            'selectedPerimetersInfo': this.selectedFirePerimeter};
         }
         break;
     }
@@ -304,7 +294,6 @@ export class WorkflowComponent implements OnInit {
   }
 
   public checkStep(type, stepNum) {
-    //console.log(this.workflowFormData[stepNum])
     if (type == 'checkbox') {
       let optionsArray = this.workflowFormData[stepNum].get('options') as FormArray;
       var result;
@@ -346,7 +335,7 @@ export class WorkflowComponent implements OnInit {
     this.stepsCompleted = 0;
     // unsubscribe to subscriptions
     this.downstreamSubscription.unsubscribe();
-    this.fireLayersSubscription.unsubscribe();
+    this.fireTraceSubscription.unsubscribe();
     this.streamflowSubscription.unsubscribe();
     this.bcSubscription.unsubscribe();
     this.geologyReportSubscription.unsubscribe();
@@ -354,7 +343,7 @@ export class WorkflowComponent implements OnInit {
     this.burnYearsSubscription.unsubscribe();
     this.basinAreaSubscription.unsubscribe();
     this.deleationSubscription.unsubscribe();
-    this.firePerimetersSubscription.unsubscribe();
+    this.firePerimeterSubscription.unsubscribe();
   }
 
   public onRadioChange(option, step) {

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -172,10 +172,6 @@ export class WorkflowComponent implements OnInit {
     this.finalStep = false; // reset final step boolean
   }
 
-  public getSteps(form: any) {
-    return form.controls.steps.controls;
-  }
-
   get workflowFormData() { 
     let stepsArray = this.workflowForm.get('steps') as FormArray;
     return stepsArray.controls; 
@@ -188,13 +184,13 @@ export class WorkflowComponent implements OnInit {
         case 'radio':
           arr.push(this._fb.group({
             text: opt.text,
-            selectedRadio: opt.selected
+            selectedRadio: false
           }));
           break;
         case 'checkbox':
           arr.push(this._fb.group({
             text: opt.text,
-            selectedCheckbox: opt.selected
+            selectedCheckbox: false
           }));
           break;
         case 'subscription':
@@ -282,13 +278,34 @@ export class WorkflowComponent implements OnInit {
   }
 
   public checkStep(type, stepNum) {
+    //console.log(this.workflowFormData[1].controls.options.controls)
     if (type == 'checkbox') {
-      const some = this.workflowForm.value.steps[stepNum].options.some((opt)=> opt.selected === true)
-      return(some)
+      //console.log('checkbox - need to check for something checked')
+      let optionsArray = this.workflowFormData[stepNum].get('options') as FormArray;
+      var result;
+      optionsArray.controls.forEach((element) => {
+        if (element.value.selectedCheckbox == true) {
+          result = true
+        }
+      });
+      return(result)
     } else if (type == "subscription") {
+      //console.log('subscription - not sure yet')
+      return(true)
+    } else if (type == 'textbox') {
+      //console.log('textbox - need to check text entered')
 
-    } else if (type == 'text') {
+    } else if (type == 'radio') {
+      //console.log('radio - need to check for something checked')
+      let optionsArray = this.workflowFormData[stepNum].get('options') as FormArray;
+      var result;
 
+      optionsArray.controls.forEach((element) => {
+        if (element.value.selectedRadio == true) {
+          result = true
+        }
+      });
+      return(result)
     }
   }
 
@@ -302,25 +319,23 @@ export class WorkflowComponent implements OnInit {
   public onRadioChange(option, step) {
     step.options.forEach(opt => {
       if (opt.text == option.text) {
-        option.selected = true;
-
+        option.selectedRadio = true;
         // TODO: Update this once delineation has more routes/branches/paths to take with in the workflow
         // such as State-Based Delineation or Open-Source Delineation. Or other future workflows. 
         if (step.name === "selectFireHydroProcess") {
           this.resetStepsArray(step);
           this.addSteps(opt.text);
         }
-		
-      } else {
-        option.selected = false;
-      }
+      } 
     });
   }
 
   public onCheckboxChange(option, step) {
+    console.log(option)
+    console.log(step)
     step.options.forEach(opt => {
       if (opt.text == option.text) {
-        option.selected = option.selected ? false : true
+        option.selectedCheckbox = option.selectedCheckbox ? false : true
       } 
     });
   }

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -251,6 +251,17 @@ export class WorkflowComponent implements OnInit {
     }
   }
 
+  public checkStep(type, stepNum) {
+    if (type == 'checkbox') {
+      const some = this.workflowForm.value.steps[stepNum].options.some((opt)=> opt.selected === true)
+      return(some)
+    } else if (type == "subscription") {
+
+    } else if (type == 'text') {
+
+    }
+  }
+
   public finishedWorkflow(formValue: any) {
     this.fillOutputs();
     this._workflowService.setCompletedData(formValue);
@@ -259,6 +270,7 @@ export class WorkflowComponent implements OnInit {
   }
 
   public onCheckboxChange(option, step) {
+
     step.options.forEach(opt => {
       if (opt.text == option.text) {
         option.selected = true;
@@ -271,7 +283,7 @@ export class WorkflowComponent implements OnInit {
         }
 		
       } else {
-        opt.selected = false;
+        option.selected = false;
       }
     });
   }

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -22,6 +22,7 @@ export class WorkflowComponent implements OnInit {
   public numberOfSteps: number;
   public finalStep: boolean = false;
   public workflowData: any;
+  public text;
   // Delination output
   public clickedPoint;
   public splitCatchmentLayer;
@@ -184,13 +185,13 @@ export class WorkflowComponent implements OnInit {
         case 'radio':
           arr.push(this._fb.group({
             text: opt.text,
-            selectedRadio: false
+            selected: false
           }));
           break;
         case 'checkbox':
           arr.push(this._fb.group({
             text: opt.text,
-            selectedCheckbox: false
+            selected: false
           }));
           break;
         case 'subscription':
@@ -278,13 +279,12 @@ export class WorkflowComponent implements OnInit {
   }
 
   public checkStep(type, stepNum) {
-    //console.log(this.workflowFormData[1].controls.options.controls)
+    //console.log(this.workflowFormData[stepNum])
     if (type == 'checkbox') {
-      //console.log('checkbox - need to check for something checked')
       let optionsArray = this.workflowFormData[stepNum].get('options') as FormArray;
       var result;
       optionsArray.controls.forEach((element) => {
-        if (element.value.selectedCheckbox == true) {
+        if (element.value.selected == true) {
           result = true
         }
       });
@@ -292,21 +292,24 @@ export class WorkflowComponent implements OnInit {
     } else if (type == "subscription") {
       //console.log('subscription - not sure yet')
       return(true)
-    } else if (type == 'textbox') {
-      //console.log('textbox - need to check text entered')
-
+    } else if (type == 'text') {
+      if (this.text && this.text.length > 0) {
+        return(true)
+      }
     } else if (type == 'radio') {
-      //console.log('radio - need to check for something checked')
       let optionsArray = this.workflowFormData[stepNum].get('options') as FormArray;
       var result;
-
       optionsArray.controls.forEach((element) => {
-        if (element.value.selectedRadio == true) {
+        if (element.value.selected == true) {
           result = true
         }
       });
       return(result)
     }
+  }
+
+  public onChangeText(string: string) {
+    this.text = string; 
   }
 
   public finishedWorkflow(formValue: any) {
@@ -319,7 +322,7 @@ export class WorkflowComponent implements OnInit {
   public onRadioChange(option, step) {
     step.options.forEach(opt => {
       if (opt.text == option.text) {
-        option.selectedRadio = true;
+        option.selected = true;
         // TODO: Update this once delineation has more routes/branches/paths to take with in the workflow
         // such as State-Based Delineation or Open-Source Delineation. Or other future workflows. 
         if (step.name === "selectFireHydroProcess") {
@@ -331,11 +334,9 @@ export class WorkflowComponent implements OnInit {
   }
 
   public onCheckboxChange(option, step) {
-    console.log(option)
-    console.log(step)
     step.options.forEach(opt => {
       if (opt.text == option.text) {
-        option.selectedCheckbox = option.selectedCheckbox ? false : true
+        option.selected = option.selected ? false : true
       } 
     });
   }

--- a/src/app/content-right/report-builder/workflow/workflow.component.ts
+++ b/src/app/content-right/report-builder/workflow/workflow.component.ts
@@ -30,7 +30,7 @@ export class WorkflowComponent implements OnInit {
   public burnAreaSubscription;
   public burnYearsSubscription;
   public basinAreaSubscription;
-  public deleationSubscription;
+  public delineationSubscription;
   public firePerimeterSubscription;
   // Delination output
   public clickedPoint;
@@ -67,7 +67,7 @@ export class WorkflowComponent implements OnInit {
       this.clickedPoint = point;
     });
     // Get delineation and basin area
-    this.deleationSubscription = this._mapService.delineationPolygon.subscribe((poly: any) => {
+    this.delineationSubscription = this._mapService.delineationPolygon.subscribe((poly: any) => {
       var basin = poly;
       if (basin) {  
         this.setSubComplete(this.stepsCompleted);
@@ -214,7 +214,7 @@ export class WorkflowComponent implements OnInit {
           break;
         case 'text':
           arr.push(this._fb.group({
-            text: opt.text
+            text: opt.text,
           }));
           break;
       }
@@ -292,7 +292,7 @@ export class WorkflowComponent implements OnInit {
   }
 
   public checkStep(type, stepNum) {
-    if (type == 'checkbox' || type == 'radio') {
+    if (type == 'radio') {
       let optionsArray = this.workflowFormData[stepNum].get('options') as FormArray;
       var result;
       optionsArray.controls.forEach((element) => {
@@ -306,9 +306,18 @@ export class WorkflowComponent implements OnInit {
         return(true)
       }
     } else if (type == 'text') {
-      if (this.text && this.text.length > 0) {
-        return(true)
-      }
+      var acceptable = [];
+      this.workflowForm.value.steps[stepNum].options.forEach(element => {
+        if (element.text && element.text.toString().length > 0) {
+          acceptable.push(true)
+        } else {
+          acceptable.push(false)
+        }
+      });
+      return acceptable.every(element => element === true);
+
+    } else if(type == 'checkbox'){
+      return(true) // currently don't have to select any checkboxes - if we need to at some point we might need to add a 'mustSelect' boolean to the workflows
     }
   }
 
@@ -331,7 +340,7 @@ export class WorkflowComponent implements OnInit {
     this. burnAreaSubscription.unsubscribe();
     this.burnYearsSubscription.unsubscribe();
     this.basinAreaSubscription.unsubscribe();
-    this.deleationSubscription.unsubscribe();
+    this.delineationSubscription.unsubscribe();
     this.firePerimeterSubscription.unsubscribe();
   }
 

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -52,7 +52,7 @@ describe('MapComponent', () => {
                   ]
               },
               {
-                "text": "Query by Fire Perimeters",
+                "text": "Query by Fire Perimeter",
                 "selected": false,
                 "nestedSteps": 
                 [

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -211,7 +211,7 @@ export class MapComponent implements OnInit {
               this.basinCharacteristics.forEach(basinCharacteristic=> {
                 basinCharacteristicArray.push(this._fb.group({
                   text: basinCharacteristic.fcpg_parameter + ": " + basinCharacteristic.description,
-                  selectedCheckbox: false
+                  selected: false
                 }));
               });
               this.workflowForm.controls.steps.controls[2].controls.options.controls = basinCharacteristicArray;
@@ -223,8 +223,8 @@ export class MapComponent implements OnInit {
           }
           if (this.workflowData.title == "Delineation" && this.workflowData.steps[2].completed) {
             // If at least one basin characteristic was selected
-            if (this.workflowForm.controls.steps.controls[2].controls.options.controls.filter((checkboxBasinCharacteristic) => checkboxBasinCharacteristic.value.selectedCheckbox).length > 0) {
-              let selectedBasinCharacteristics = this.workflowForm.controls.steps.controls[2].controls.options.controls.filter(checkboxBasinCharacteristic => checkboxBasinCharacteristic.value.selectedCheckbox == true);
+            if (this.workflowForm.controls.steps.controls[2].controls.options.controls.filter((checkboxBasinCharacteristic) => checkboxBasinCharacteristic.value.selected).length > 0) {
+              let selectedBasinCharacteristics = this.workflowForm.controls.steps.controls[2].controls.options.controls.filter(checkboxBasinCharacteristic => checkboxBasinCharacteristic.value.selected == true);
               let selectedBasinCharacteristicCodes = selectedBasinCharacteristics.map(checkboxBasinCharacteristic => checkboxBasinCharacteristic.value.text.substr(0, checkboxBasinCharacteristic.value.text.indexOf(':')));
               this.basinCharacteristics = this.basinCharacteristics.filter((basinCharacteristic) => selectedBasinCharacteristicCodes.includes(basinCharacteristic.fcpg_parameter));
               this._mapService.setBasinCharacteristics(this.basinCharacteristics);

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -266,7 +266,7 @@ export class MapComponent implements OnInit {
     });
 
     // Get selected fire perimeters
-    this._mapService.selectedPerimeters.subscribe((perimeter) => {
+    this._mapService.selectedFirePerimeter.subscribe((perimeter) => {
       this.selectedPerimeter = perimeter;
       //remove old highlight
       if (this.selectedPerimeterHighlight) {
@@ -317,7 +317,7 @@ export class MapComponent implements OnInit {
             if (this.workflowData && this.workflowData.steps) {
               this.workflowData.steps[0].options.forEach((o: { text: string; selected: boolean; }) => {
                 if (o.selected == true) {
-                  if (o.text === "Query by Fire Perimeters" || o.text === "Query by Basin") {
+                  if (o.text === "Query by Fire Perimeter" || o.text === "Query by Basin") {
                     if (o.text === "Query by Basin") {
                       this.addLayers('NHD Flowlines', true);
                     }
@@ -688,7 +688,7 @@ export class MapComponent implements OnInit {
     var regex = /(?<=\>)(\d*)(?=\<\/p>)/g;
     var result = text.match(regex)[0];
     //  select new perimeter
-    this._mapService.setSelectedPerimeters(this.firesinClick[result]);
+    this._mapService.setSelectedFirePerimeter(this.firesinClick[result]);
     // set trace data 
     this.traceData = this.firesinClick[result].Data;
   }
@@ -706,7 +706,7 @@ export class MapComponent implements OnInit {
           }
         });   
       } 
-      this._mapService.setFirePerimetersLayers(this.firePerimeterLayer, this.traceLayer);
+      this._mapService.setFireTraceLayers(this.firePerimeterLayer, this.traceLayer);
       this.outputLayers.addLayer(this.traceLayer);
       this._mapService.map.fitBounds(this.traceLayer.getBounds(), { padding: [75,75] });
       this._loaderService.hideFullPageLoad();

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -239,7 +239,7 @@ export class MapComponent implements OnInit {
             if (this.workflowData.steps[1].name === "selectFireHydroBasin" && this.workflowData.steps[2].completed) {
               this.queryBurnYear();
             }
-            if (this.workflowData.steps[1].name === "selectFireHydroPerimeter"  && this.workflowData.steps[3].completed) {
+            if (this.workflowData.steps[1].name === "selectFireHydroPerimeter"  && this.workflowData.steps[2].completed) {
               this._loaderService.showFullPageLoad();
               this.addTraceLayer(this.traceData);
             }

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -670,6 +670,7 @@ export class MapService {
     // Get selected Fire Perimeters
     private _selectedPerimeters: Subject<any> = new Subject<any>();
     public setSelectedPerimeters(array) {
+        console.log('hhi')
         this._selectedPerimeters.next(array);
     }
     public get selectedPerimeters(): any {

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -660,21 +660,20 @@ export class MapService {
     }
 
     // Get selected Fire Perimeters layers
-    private _selectedPerimetersLayer: Subject<any> = new Subject<any>();
-    public setFirePerimetersLayers(firePerimeters: any, trace: any) {
-        this._selectedPerimetersLayer.next([firePerimeters, trace]);
+    private _fireLayers: Subject<any> = new Subject<any>();
+    public setFireTraceLayers(firePerimeters: any, trace: any) {
+        this._fireLayers.next([firePerimeters, trace]);
     }
-    public get firePerimetersLayers(): any {
-        return this._selectedPerimetersLayer.asObservable();
+    public get fireTraceLayers(): any {
+        return this._fireLayers.asObservable();
     }
     // Get selected Fire Perimeters
-    private _selectedPerimeters: Subject<any> = new Subject<any>();
-    public setSelectedPerimeters(array) {
-        console.log('hhi')
-        this._selectedPerimeters.next(array);
+    private _selectedFirePerimeter: Subject<any> = new Subject<any>();
+    public setSelectedFirePerimeter(perimeter) {
+        this._selectedFirePerimeter.next(perimeter);
     }
-    public get selectedPerimeters(): any {
-        return this._selectedPerimeters.asObservable();
+    public get selectedFirePerimeter(): any {
+        return this._selectedFirePerimeter.asObservable();
     }
 
     private createMessage(msg: string, mType: string = messageType.INFO, title?: string, timeout?: number) {

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -72,7 +72,6 @@ export class MapService {
             });
     
         }
-        // TODO: Load overlay layers?
         if (this.configSettings) {
             this.configSettings.overlays.forEach(ml => {
                 try {

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -87,7 +87,7 @@
                                 "label":"Burn Area Year Range",
                                 "description": "Enter a start and end date for the burn area year range.",
                                 "name": "burnAreaYearRange",
-                                "type": "text",
+                                "type": "textbox",
                                 "cursor": "auto",
                                 "validators": 
                                 {
@@ -134,7 +134,7 @@
                                 "label": "Enter Downstream Trace Distance",
                                 "description": "Enter the distance (kilometers) to trace stream lines downstream of the fire perimeter.",
                                 "name": "enterDownstreamDistance",
-                                "type": "text",
+                                "type": "textbox",
                                 "cursor": "auto",
                                 "validators": 
                                 {

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -87,7 +87,7 @@
                                 "label":"Burn Area Year Range",
                                 "description": "Enter a start and end date for the burn area year range.",
                                 "name": "burnAreaYearRange",
-                                "type": "textbox",
+                                "type": "text",
                                 "cursor": "auto",
                                 "validators": 
                                 {
@@ -134,7 +134,7 @@
                                 "label": "Enter Downstream Trace Distance",
                                 "description": "Enter the distance (kilometers) to trace stream lines downstream of the fire perimeter.",
                                 "name": "enterDownstreamDistance",
-                                "type": "textbox",
+                                "type": "text",
                                 "cursor": "auto",
                                 "validators": 
                                 {

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -108,7 +108,7 @@
                         ]
                     },
                     {
-                        "text": "Query by Fire Perimeters",
+                        "text": "Query by Fire Perimeter",
                         "selected": false,
                         "nestedSteps": 
                         [

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -97,11 +97,11 @@
                                 [
                                     {
                                         "textLabel":"Start Year",
-                                        "text":"1900"
+                                        "text": 1900
                                     },
                                     {
                                         "textLabel":"End Year",
-                                        "text":"2022"
+                                        "text": 2022
                                     }
                                 ]
                             }

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -146,24 +146,6 @@
                                         "textLabel":"Downstream Trace Distance"
                                     }
                                 ]
-                            },
-                            {
-                                "label": "Trace Fire Perimeter",
-                                "description": "",
-                                "name": "traceFireHydroPerimeter",
-                                "type": "subscription",
-                                "cursor": "auto",
-                                "validators": 
-                                {
-                                    "required": true
-                                },
-                                "options": 
-                                [
-                                    {
-                                        "text": "Click 'Next' to trace downstream.",
-                                        "selected": false
-                                    }
-                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
- Disabled 'next' until user adequately completes the step.
- Got rid of 'ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked' console error.
- Renamed 'Query by Fire Perimeters' workflow to 'Query by Fire Perimeter' since you can now only select one.
- Renamed some fire perimeter getters and setters so they make more sense (i hope).
- Removed 'Trace Fire Perimeter' - It didn't do anything except start the service call which now just starts when user selects next.
- Cleaned up unused variables in `workflow.component`.