### PR TITLE
Fixes #264 - Update fire layers for 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Burn Severity is turned off by default for Fire Hydrology workflows
 - Some checkboxes are now radio buttons where appropriate
 - 'Query by Fire Perimeters' workflow to 'Query by Fire Perimeter' 
+- '2022 Wildland Fire Perimeters' renamed to 'Current Year Wildland Fire Perimeters'
 
 ### Deprecated 
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -324,7 +324,7 @@ export class MapComponent implements OnInit {
                     this.addLayers('2000-2018 Wildland Fire Perimeters', true);
                     this.addLayers('2019 Wildland Fire Perimeters', true);
                     this.addLayers('2021 Wildland Fire Perimeters', true);
-                    this.addLayers('2022 Wildland Fire Perimeters', true);
+                    this.addLayers('Current Year Wildland Fire Perimeters', true);
                     this.addLayers('MTBS Fire Boundaries', true);
                     this.addLayers('Burn Severity', false);
                   }
@@ -583,7 +583,7 @@ export class MapComponent implements OnInit {
     Object.keys(this.workflowLayers).forEach(layerName => {
       if (this.activeWorkflowLayers.find(layer => layer.name === layerName)) {
         if (this.activeWorkflowLayers.find(layer => layer.name === layerName).visible == true) {
-          if (layerName === '2022 Wildland Fire Perimeters' || layerName === '2021 Wildland Fire Perimeters' || layerName === '2019 Wildland Fire Perimeters' || layerName === '2000-2018 Wildland Fire Perimeters' || layerName === 'MTBS Fire Boundaries') {
+          if (layerName === 'Current Year Wildland Fire Perimeters' || layerName === '2021 Wildland Fire Perimeters' || layerName === '2019 Wildland Fire Perimeters' || layerName === '2000-2018 Wildland Fire Perimeters' || layerName === 'MTBS Fire Boundaries') {
             this.workflowLayers[layerName].query().nearby(this.clickPoint, 4).returnGeometry(true)
               .run((error: any, results: any) => {
                 this.findFireFeatures(error, results, layerName);

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -451,7 +451,7 @@ export class MapService {
             
             Object.keys(this.workflowLayers).forEach(workflowLayer => {
                 let queryString;
-                if (workflowLayer == "2000-2018 Wildland Fire Perimeters" || workflowLayer == "2019 Wildland Fire Perimeters" || workflowLayer == "2021 Wildland Fire Perimeters" || workflowLayer == '2022 Wildland Fire Perimeters') {
+                if (workflowLayer == "2000-2018 Wildland Fire Perimeters" || workflowLayer == "2019 Wildland Fire Perimeters" || workflowLayer == "2021 Wildland Fire Perimeters" || workflowLayer == 'Current Year Wildland Fire Perimeters') {
                     if (workflowLayer == "2000-2018 Wildland Fire Perimeters") {
                         // TO DO #194
                         if (startBurnYear >= (new Date()).getFullYear()) {
@@ -468,7 +468,7 @@ export class MapService {
                             count ++;
                         }
                         queryString = '1=1';
-                    } else if (workflowLayer == "2022 Wildland Fire Perimeters") {
+                    } else if (workflowLayer == "Current Year Wildland Fire Perimeters") {
                         if (endBurnYear <= (new Date()).getFullYear()) {
                             count ++;
                         }

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -32,7 +32,7 @@
         }
         },
         {
-            "name": "2022 Wildland Fire Perimeters",
+            "name": "Current Year Wildland Fire Perimeters",
             "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/CY_WildlandFire_Perimeters_ToDate/FeatureServer/0",
             "type": "agsFeature",
             "layerOptions": {
@@ -169,7 +169,7 @@
             "color": "#3CB043",
             "fillColor": "#3CB043"
         },
-        "2022 Wildland Fire Perimeters": {
+        "Current Year Wildland Fire Perimeters": {
             "color": "#EBCF26",
             "fillColor": "#EBCF26"
         },

--- a/src/assets/workflows.json
+++ b/src/assets/workflows.json
@@ -101,7 +101,7 @@
                                     },
                                     {
                                         "textLabel":"End Year",
-                                        "text": 2022
+                                        "text": 2023
                                     }
                                 ]
                             }


### PR DESCRIPTION
Closes #264 

The "2022 Wildland Fire Perimeters" layer was updated to 2023: https://data-nifc.opendata.arcgis.com/datasets/nifc::wfigs-2023-wildland-fire-perimeters-to-date/about

I changed "2022 Wildland Fire Perimeters" to "Current Year Wildland Fire Perimeters" so we don't have to keep updating.

It appears that we are now not able to show 2020 nor 2022 wildland fires. I can't find these fires on the NIFC website and contacted them for assistance. 