### PR TITLE
Release v1.3.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added 
 
+- 
+
+### Changed  
+
+- 
+
+### Deprecated 
+
+-
+
+### Removed 
+
+- 
+
+### Fixed  
+
+- 
+### Security  
+
+- 
+## [v1.3.0-beta](https://github.com/USGS-WiM/StreamStats-National/releases/tag/v1.3.0-beta) - 2023-01-11
+
+### Added 
+
 - Allows users to enter downstream distance in "Query by Fire Perimeters" workflow
 - Descriptions to workflows and steps
 - Added cursor attribute to workflows
@@ -32,11 +56,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Some checkboxes are now radio buttons where appropriate
 - 'Query by Fire Perimeters' workflow to 'Query by Fire Perimeter' 
 - '2022 Wildland Fire Perimeters' renamed to 'Current Year Wildland Fire Perimeters'
-
-### Deprecated 
-
--
-
 ### Removed 
 
 - Removed 'Trace Fire Perimeter' step
@@ -47,10 +66,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - In print modal, description text not up taking full width of modal
 - Only query fire perimeters that are visible
 - Bug caused by switching between report and workflow that reset workflow variables which created errors
-
-### Security  
-
-- 
 
 ## [v1.2.0-beta](https://github.com/USGS-WiM/StreamStats-National/releases/tag/v1.2.0-beta) - 2022-07-14
 

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "StreamStats National",
     "organization": "U.S. Geological Survey",
     "description": "Web-based Geographic Information Systems application that provides users with access to hydrologic data and analytical tools",
-    "version": "v1.2.0-beta",
+    "version": "1.3.0-beta",
     "status": "Beta",
 
     "permissions": {
@@ -43,7 +43,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2022-07-14"
+      "metadataLastUpdated": "2023-01-11"
     }
   }
 ]

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "v1.2.0-beta",
+    "version": "v1.3.0-beta",
     "workflowsURL": "assets/workflows.json",
     "nldiBaseURL": "https://labs.waterdata.usgs.gov/api/nldi/pygeoapi/processes/",
     "nldiSplitCatchmentURL": "nldi-splitcatchment/execution",


### PR DESCRIPTION
- Updated CHANGELOG.md
- Update version number in code.json and config.json

# Release v1.3.0-beta

### Added 

- Allows users to enter downstream distance in "Query by Fire Perimeters" workflow
- Descriptions to workflows and steps
- Added cursor attribute to workflows
- Basin characteristics computation to "Delineation" workflow
- Disabled 'next' until user adequately completes the step
- "Query by Fire Perimeters" workflow now shows downstream gages

### Changed  

- Split 'Select a Fire Perimeter' step in 'Query by Fire Perimeters' workflow into two separate steps. The first is to select your fire perimeter the second it to start the trace
- Updated layout
- Fire perimeters labels 
- Pointer marker now points to clicked point instead of being centered on clicked point
- 'Overview' to 'Report'
- Print modal - spacing, moved buttons to bottom
- Only able to trace/select once fire perimeter at a time
- Remove all output workflow layers when workflow is complete
- Updated to google analytics 4
- Burn Severity is turned off by default for Fire Hydrology workflows
- Some checkboxes are now radio buttons where appropriate
- 'Query by Fire Perimeters' workflow to 'Query by Fire Perimeter' 
- '2022 Wildland Fire Perimeters' renamed to 'Current Year Wildland Fire Perimeters'

### Removed 

- Removed 'Trace Fire Perimeter' step

### Fixed  

- USGS search API library reference
- In print modal, description text not up taking full width of modal
- Only query fire perimeters that are visible
- Bug caused by switching between report and workflow that reset workflow variables which created errors

