### PR TITLE
Fixes #271

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed  
 
 - In "Delineation" workflow, only return Basin Characteristics that are available at the clicked point
+- In "Query by Fire Perimeter", fixed bug causes it to not select a perimeter
 
 ### Security  
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -60,7 +60,7 @@ export class MapComponent implements OnInit {
   clickout(event) 
   { 
     if (event.target.classList.contains("selectFire")) {
-      this.selectFire(event.path[2].innerHTML); 
+      this.selectFire(event.target.innerHTML); 
     }
   }
 
@@ -655,8 +655,7 @@ export class MapComponent implements OnInit {
       'IRWIN_UNIQUEFIREIDENTIFIER':"Unique Fire Identifier"
     };
 
-    popupcontent = '<p hidden>' + this.numFiresInClick + '</p>'
-    popupcontent += '<div class="popup-header"><b>' + layerName + '</b></div><hr>';
+    popupcontent = '<div class="popup-header"><b>' + layerName + '</b></div><hr>';
     if (layerName === 'MTBS Fire Boundaries') {
       let date = feat.properties.STARTMONTH + '/' + feat.properties.STARTDAY + '/' + feat.properties.YEAR;
       if (date.indexOf('undefined') > -1) date = 'N/A';
@@ -673,8 +672,7 @@ export class MapComponent implements OnInit {
       } 
     });
     popupcontent += '<br>'; 
-    popupcontent += '<center><button class="selectFire usa-button">Select Fire</button></center>'
-
+    popupcontent += '<center><button class="selectFire usa-button">Select Fire<p hidden>' + this.numFiresInClick + '</p></button></center>'
     this.firePerimeterLayer = L.geoJSON(feat.geometry);
     this.addBurnPoint(this.firePerimeterLayer.getBounds().getCenter(), popupcontent);
     feat.properties = properties;


### PR DESCRIPTION
Not sure when this broke but I noticed when reviewing, https://github.com/USGS-WiM/StreamStats-National/pull/270.

For some reason the `event` no longer had a `path` associated with it. I edited the popup content to have the number of the fire in the button html and instead look at the `event.target`. 