### PR TITLE
Fixes #227 - Highlight Report Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed  
 
-- 
+- The Report tab now automatically opens after completing a workflow
 
 ### Deprecated 
 

--- a/src/app/content-right/content-right.component.ts
+++ b/src/app/content-right/content-right.component.ts
@@ -23,6 +23,9 @@ export class ContentRightComponent implements OnInit {
         }
 
         this._workflowService.formData.subscribe(data => {
+            if (this.formData && data == null) {
+                this.tab = 2; // Switch to Report tab after a workflow has completed
+            }
             this.formData = data;
         })
 
@@ -35,6 +38,7 @@ export class ContentRightComponent implements OnInit {
     public removeWorkFlow() {
         this._workflowService.setSelectedWorkflow(null);
         this._workflowService.setFormData(null);
+        this.tab = 1; // Keep the tab on "Build Report" when exiting a workflow
     }
 
 }


### PR DESCRIPTION
Closes #227 

Rather than highlighting the report tab, I solved this by automatically switching to the report tab when a workflow is completed. I welcome your thoughts about this, and/or we can discuss at the next check-in.