### PR TITLE
Fixes #277 - Update fire map services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed  
 
-- 
+- Fire map services due to NIFC updates
 
 ### Deprecated 
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -645,14 +645,14 @@ export class MapComponent implements OnInit {
       'STARTMONTH':"Start Month",
       'STARTDAY':"Start Day",
       'FIRE_TYPE':"Fire Type",					  
-      'POLY_INCIDENTNAME':"Incident Name",
-      'POLY_GISACRES':"Acres",
-      'POLY_DATECURRENT':"Modified Date",
-      'IRWIN_FIRECAUSE':"Fire Cause",
-      'IRWIN_FIRECAUSEGENERAL':"Fire Cause-General",
-      'IRWIN_FIREDISCOVERYDATETIME':"Fire Discovery Date Time",
-      'IRWIN_FIREOUTDATETIME':"Fire Out Date Time",
-      'IRWIN_UNIQUEFIREIDENTIFIER':"Unique Fire Identifier"
+      'attr_IncidentName':"Incident Name",
+      'poly_GISAcres':"Acres",
+      'poly_CreateDate':"Create Date",
+      'attr_FireCause':"Fire Cause",
+      'attr_FireCauseGeneral':"Fire Cause-General",
+      'attr_FireDiscoveryDateTime':"Fire Discovery Date Time",
+      'attr_FireOutDateTime':"Fire Out Date Time",
+      'attr_UniqueFireIdentifier':"Unique Fire Identifier"
     };
 
     popupcontent = '<div class="popup-header"><b>' + layerName + '</b></div><hr>';

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -321,7 +321,7 @@ export class MapComponent implements OnInit {
                     }
                     this.addLayers('2000-2018 Wildland Fire Perimeters', true);
                     this.addLayers('2019 Wildland Fire Perimeters', true);
-                    this.addLayers('2021 Wildland Fire Perimeters', true);
+                    this.addLayers('2021-Present Wildland Fire Perimeters', true);
                     this.addLayers('Current Year Wildland Fire Perimeters', true);
                     this.addLayers('MTBS Fire Boundaries', true);
                     this.addLayers('Burn Severity', false);
@@ -579,7 +579,7 @@ export class MapComponent implements OnInit {
     Object.keys(this.workflowLayers).forEach(layerName => {
       if (this.activeWorkflowLayers.find(layer => layer.name === layerName)) {
         if (this.activeWorkflowLayers.find(layer => layer.name === layerName).visible == true) {
-          if (layerName === 'Current Year Wildland Fire Perimeters' || layerName === '2021 Wildland Fire Perimeters' || layerName === '2019 Wildland Fire Perimeters' || layerName === '2000-2018 Wildland Fire Perimeters' || layerName === 'MTBS Fire Boundaries') {
+          if (layerName === 'Current Year Wildland Fire Perimeters' || layerName === '2021-Present Wildland Fire Perimeters' || layerName === '2019 Wildland Fire Perimeters' || layerName === '2000-2018 Wildland Fire Perimeters' || layerName === 'MTBS Fire Boundaries') {
             this.workflowLayers[layerName].query().nearby(this.clickPoint, 4).returnGeometry(true)
               .run((error: any, results: any) => {
                 this.findFireFeatures(error, results, layerName);

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -645,14 +645,14 @@ export class MapComponent implements OnInit {
       'STARTMONTH':"Start Month",
       'STARTDAY':"Start Day",
       'FIRE_TYPE':"Fire Type",					  
-      'attr_IncidentName':"Incident Name",
-      'poly_GISAcres':"Acres",
-      'poly_CreateDate':"Create Date",
-      'attr_FireCause':"Fire Cause",
-      'attr_FireCauseGeneral':"Fire Cause-General",
-      'attr_FireDiscoveryDateTime':"Fire Discovery Date Time",
-      'attr_FireOutDateTime':"Fire Out Date Time",
-      'attr_UniqueFireIdentifier':"Unique Fire Identifier"
+      'ATTR_INCIDENTNAME':"Incident Name",
+      'POLY_GISACRES':"Acres",
+      'POLY_CREATEDATE':"Create Date",
+      'ATTR_FIRECAUSE':"Fire Cause",
+      'ATTR_FIRECAUSEGENERAL':"Fire Cause-General",
+      'ATTR_FIREDISCOVERYDATETIME':"Fire Discovery Date Time",
+      'ATTR_FIREOUTDATETIME':"Fire Out Date Time",
+      'ATTR_UNIQUEFIREIDENTIFIER':"Unique Fire Identifier"
     };
 
     popupcontent = '<div class="popup-header"><b>' + layerName + '</b></div><hr>';

--- a/src/app/shared/services/map.service.ts
+++ b/src/app/shared/services/map.service.ts
@@ -451,7 +451,7 @@ export class MapService {
             
             Object.keys(this.workflowLayers).forEach(workflowLayer => {
                 let queryString;
-                if (workflowLayer == "2000-2018 Wildland Fire Perimeters" || workflowLayer == "2019 Wildland Fire Perimeters" || workflowLayer == "2021 Wildland Fire Perimeters" || workflowLayer == 'Current Year Wildland Fire Perimeters') {
+                if (workflowLayer == "2000-2018 Wildland Fire Perimeters" || workflowLayer == "2019 Wildland Fire Perimeters" || workflowLayer == "2021-Present Wildland Fire Perimeters" || workflowLayer == 'Current Year Wildland Fire Perimeters') {
                     if (workflowLayer == "2000-2018 Wildland Fire Perimeters") {
                         // TO DO #194
                         if (startBurnYear >= (new Date()).getFullYear()) {
@@ -463,7 +463,7 @@ export class MapService {
                             count++;
                         }
                         queryString = 'fireyear >= ' + startBurnYear.toString() + ' AND fireyear <= ' + endBurnYear.toString();
-                    } else if (workflowLayer == "2021 Wildland Fire Perimeters") {
+                    } else if (workflowLayer == "2021-Present Wildland Fire Perimeters") {
                         if (endBurnYear < (new Date()).getFullYear()) {
                             count ++;
                         }

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -181,7 +181,7 @@
             "color": "#EBCF26",
             "fillColor": "#EBCF26"
         },
-        "2021 Wildland Fire Perimeters": {
+        "2021-Present Wildland Fire Perimeters": {
             "color": "#ed8f24",
             "fillColor": "#ed8f24"
         },

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -71,7 +71,9 @@
             "layerOptions": {
                 "zIndex": 9999
             },
-            "visible": true
+            "visible": true,
+            "layerNameNIFC": "Historic Perimeters Combined 2000-2018 GeoMAC",
+            "urlNIFC": "https://data-nifc.opendata.arcgis.com/datasets/nifc::historic-perimeters-combined-2000-2018-geomac/about"
         },
         {
             "name": "MTBS Fire Boundaries",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -43,13 +43,15 @@
             "urlNIFC": "https://data-nifc.opendata.arcgis.com/datasets/nifc::wfigs-2023-interagency-fire-perimeters-to-date/about"
         },
         {
-            "name": "2021 Wildland Fire Perimeters",
-            "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/Fire_History_Perimeters_Public/FeatureServer/0",
+            "name": "2021-Present Wildland Fire Perimeters",
+            "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/WFIGS_Interagency_Perimeters/FeatureServer/0",
             "type": "agsFeature",
             "layerOptions": {
                 "zIndex": 9999
             },
-            "visible": true
+            "visible": true,
+            "layerNameNIFC": "WFIGS Interagency Fire Perimeters",
+            "urlNIFC": "https://data-nifc.opendata.arcgis.com/datasets/nifc::wfigs-interagency-fire-perimeters/about"
         },
         {
             "name": "2019 Wildland Fire Perimeters",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -33,12 +33,14 @@
         },
         {
             "name": "Current Year Wildland Fire Perimeters",
-            "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/CY_WildlandFire_Perimeters_ToDate/FeatureServer/0",
+            "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/WFIGS_Interagency_Perimeters_YearToDate/FeatureServer/0",
             "type": "agsFeature",
             "layerOptions": {
                 "zIndex": 9999
             },
-            "visible": true
+            "visible": true,
+            "layerNameNIFC": "WFIGS 2023 Interagency Fire Perimeters to Date",
+            "urlNIFC": "https://data-nifc.opendata.arcgis.com/datasets/nifc::wfigs-2023-interagency-fire-perimeters-to-date/about"
         },
         {
             "name": "2021 Wildland Fire Perimeters",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -60,7 +60,9 @@
             "layerOptions": {
                 "zIndex": 9999
             },
-            "visible": true
+            "visible": true,
+            "layerNameNIFC": "Historic Perimeters 2019",
+            "urlNIFC": "https://data-nifc.opendata.arcgis.com/datasets/nifc::historic-perimeters-2019/about"
         },
         {
             "name": "2000-2018 Wildland Fire Perimeters",


### PR DESCRIPTION
Only 2 map services needed to be updated:
1. Current Year Wildland Fire Perimeters
2. 2021 Wildland Fire Perimeters (which was renamed to 2021-Present Wildland Fire Perimeters)

I also added the NIFC layer names and URLs to the config.json so it is easier to find these layers in the future. I think the NIFC will continue to update and change these layers. 