### PR TITLE
Release v1.4.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added 
 
+- 
+
+### Changed  
+
+- 
+
+### Deprecated 
+
+-
+
+### Removed 
+
+- 
+
+### Fixed  
+
+- 
+
+### Security  
+
+- 
+
+## [v1.4.0-beta](https://github.com/USGS-WiM/StreamStats-National/releases/tag/v1.4.0-beta) - 2023-03-15
+
+### Added 
+
 - "WFIGS - Wildland Fire Perimeters Full History" layer to fire hydrology workflows
 - "Interagency Fire Perimeter History - All Years" layer to fire hydrology workflows
 
@@ -20,10 +46,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Unavailable grid query service values are evaluated as null rather than -9999
 - Improved notification when dependent services are unavailable
 
-### Deprecated 
-
--
-
 ### Removed 
 
 - "2021 Fire Perimeters" layer from fire hydrology workflows
@@ -32,11 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - In "Delineation" workflow, only return Basin Characteristics that are available at the clicked point
 - In "Query by Fire Perimeter", fixed bug causes it to not select a perimeter
-- Query strings used to query fire perimeter map layer geometry in queryBurnedArea function
-
-### Security  
-
-- 
+- Query strings used to query fire perimeter map layer geometry in queryBurnedArea function 
 ## [v1.3.0-beta](https://github.com/USGS-WiM/StreamStats-National/releases/tag/v1.3.0-beta) - 2023-01-11
 
 ### Added 

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "StreamStats National",
     "organization": "U.S. Geological Survey",
     "description": "Web-based Geographic Information Systems application that provides users with access to hydrologic data and analytical tools",
-    "version": "1.3.0-beta",
+    "version": "1.4.0-beta",
     "status": "Beta",
 
     "permissions": {
@@ -43,7 +43,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2023-01-11"
+      "metadataLastUpdated": "2023-03-15"
     }
   }
 ]

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "v1.3.0-beta",
+    "version": "v1.4.0-beta",
     "workflowsURL": "assets/workflows.json",
     "nldiBaseURL": "https://labs.waterdata.usgs.gov/api/nldi/pygeoapi/processes/",
     "nldiSplitCatchmentURL": "nldi-splitcatchment/execution",


### PR DESCRIPTION
Part of #280 

# Release v1.4.0-beta
### Added 

- "WFIGS - Wildland Fire Perimeters Full History" layer to fire hydrology workflows
- "Interagency Fire Perimeter History - All Years" layer to fire hydrology workflows

### Changed  

- The Report tab now automatically opens after completing a workflow
- Fire map services due to NIFC updates
- Unavailable grid query service values are evaluated as null rather than -9999
- Improved notification when dependent services are unavailable

### Removed 

- "2021 Fire Perimeters" layer from fire hydrology workflows

### Fixed  

- In "Delineation" workflow, only return Basin Characteristics that are available at the clicked point
- In "Query by Fire Perimeter", fixed bug causes it to not select a perimeter
- Query strings used to query fire perimeter map layer geometry in queryBurnedArea function
